### PR TITLE
Fix Safari favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
   <meta property="og:description" content="Fast, fair, and reliable scrap services in Demo City."/>
   <meta property="og:image" content="assets/og-image.jpg"/>
   <!-- Favicon -->
-  <link rel="icon" href="assets/logo.png" type="image/png" sizes="any"/>
+  <link rel="icon" href="assets/logo.svg" type="image/svg+xml"/>
+  <link rel="icon" href="assets/logo.png" type="image/png"/>
   <link rel="mask-icon" href="assets/logo.svg" color="#D75E02"/>
   <link rel="apple-touch-icon" href="assets/logo.png"/>
   <!-- Tailwind 3 CDN -->


### PR DESCRIPTION
## Summary
- fix head icon markup so Safari picks up the favicon properly

## Testing
- `pip install Pillow`

------
https://chatgpt.com/codex/tasks/task_e_686841583ee88329b173f2c493144f99