### PR TITLE
Restore visit map and card animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,6 @@
     </a>
     <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 items-center gap-8 text-sm font-medium">
       <a href="#materials" class="hover:text-brand-orange">What We Buy</a>
-      <a href="#why"       class="hover:text-brand-orange">Why Us</a>
       <a href="#visit"     class="hover:text-brand-orange">Visit</a>
       <a href="#contact"   class="hover:text-brand-orange">Quote</a>
     </nav>
@@ -139,21 +138,21 @@
     <h2 class="text-3xl font-bold mb-8">How It Works</h2>
   </div>
   <div class="mt-12 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow p-8 flex items-start gap-4">
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow p-8 flex items-start gap-4" data-aos>
       <span class="text-5xl font-bold text-brand-orange">1</span>
       <div>
         <h3 class="font-semibold mb-2">Check Your Material</h3>
         <p class="text-sm text-brand-steel">Copper, aluminum, steel, converters, batteries & more.</p>
       </div>
     </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow p-8 flex items-start gap-4">
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow p-8 flex items-start gap-4" data-aos data-aos-delay="50">
       <span class="text-5xl font-bold text-brand-orange">2</span>
       <div>
         <h3 class="font-semibold mb-2">Drive On & Unload</h3>
         <p class="text-sm text-brand-steel">Roll onto the scale and our crew takes care of the rest.</p>
       </div>
     </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow p-8 flex items-start gap-4">
+    <div class="rounded-xl bg-white border border-brand-steel/10 shadow p-8 flex items-start gap-4" data-aos data-aos-delay="100">
       <span class="text-5xl font-bold text-brand-orange">3</span>
       <div>
         <h3 class="font-semibold mb-2">Get Paid</h3>
@@ -205,7 +204,18 @@
   </div>
 </section>
 
-
+<!-- ── Visit ───────────────────────────────────────────────-->
+<section id="visit" class="scroll-mt-16 py-20 bg-white">
+  <div class="max-w-4xl mx-auto px-6 text-center">
+    <h2 class="text-3xl font-bold mb-4">Visit Our Yard</h2>
+    <p class="text-brand-steel text-base md:text-sm">
+      <strong>Hours:</strong> Mon–Fri 8 am–5 pm · Sat 8 am–1 pm<br/>
+      <strong>Address:</strong> 123 Demo Rd, Demo City, TX 77001<br/>
+      <strong>Phone:</strong> <a href="tel:+15551234567" class="underline">555‑123‑4567</a>
+    </p>
+    <iframe class="mt-10 w-full h-[350px] border-0 rounded-lg shadow" loading="lazy" src="https://www.google.com/maps/embed/v1/place?key=YOUR_GOOGLE_MAPS_API_KEY&q=Demo+City+TX"></iframe>
+  </div>
+</section>
 
 <!-- ── Contact ─────────────────────────────────────────────-->
 <section id="contact" class="scroll-mt-16 py-20 bg-gray-100">


### PR DESCRIPTION
## Summary
- remove unused "Why Us" link
- animate How It Works cards
- reintroduce Visit section with embedded map

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684592f83083298405899ad79631db