### PR TITLE
Revert footer to prior style

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,12 +240,8 @@
 
 <!-- ── Footer ──────────────────────────────────────────────-->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <p>© <span id="year"></span> Demo Yard · <a href="tel:+15551234567" class="underline">555-123-4567</a></p>
+  <p>© <span id="year"></span> <a href="https://scrapyardsites.com" target="_blank" class="underline">Scrapyard Sites</a> — All rights reserved.</p>
 </footer>
-
-<div class="md:hidden fixed bottom-0 inset-x-0 bg-brand-orange text-white text-center py-3 z-50">
-  <a href="tel:+15551234567" class="font-semibold">Call Now</a>
-</div>
 <!-- Scripts -->
 <script>
   /* dynamic year */


### PR DESCRIPTION
## Summary
- revert phone footer to previous "Scrapyard Sites" credit
- remove bottom call bar

## Testing
- `grep -n "Call Now" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_686845a931f0832982744a1ce45d9d3b