### PR TITLE
Add icons and card design

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,12 +174,21 @@
 <!-- Commercial Services Call-out -->
 <section class="py-12 bg-brand-charcoal text-white">
   <div class="max-w-4xl mx-auto px-6 text-center">
-    <h2 class="text-2xl font-bold mb-4">Commercial Services</h2>
-    <ul class="space-y-2 text-sm">
-      <li>Roll-off containers (20–40 yd)</li>
-      <li>Demo scrap removal</li>
-      <li>Scheduled plant pickups</li>
-    </ul>
+    <h2 class="text-2xl font-bold mb-8">Commercial Services</h2>
+    <div class="grid gap-6 md:grid-cols-3 text-sm">
+      <div class="rounded-lg border border-white/20 bg-white/10 p-6 flex flex-col items-center gap-3" data-aos>
+        <i class="fa-solid fa-dumpster text-3xl text-brand-orange"></i>
+        <p>Roll-off containers (20–40 yd)</p>
+      </div>
+      <div class="rounded-lg border border-white/20 bg-white/10 p-6 flex flex-col items-center gap-3" data-aos data-aos-delay="50">
+        <i class="fa-solid fa-recycle text-3xl text-brand-orange"></i>
+        <p>Demo scrap removal</p>
+      </div>
+      <div class="rounded-lg border border-white/20 bg-white/10 p-6 flex flex-col items-center gap-3" data-aos data-aos-delay="100">
+        <i class="fa-solid fa-calendar-check text-3xl text-brand-orange"></i>
+        <p>Scheduled plant pickups</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -223,12 +232,21 @@
 <!-- Before-You-Arrive Checklist -->
 <section id="checklist" class="py-16 bg-gray-100">
   <div class="max-w-4xl mx-auto px-6">
-    <h2 class="text-2xl font-bold mb-4 text-center">Before You Arrive</h2>
-    <ul class="list-disc list-inside text-sm text-brand-steel space-y-2">
-      <li>ID required</li>
-      <li>PPE tips</li>
-      <li>Prohibited items (Freon tanks, sealed drums, ammo)</li>
-    </ul>
+    <h2 class="text-2xl font-bold mb-8 text-center">Before You Arrive</h2>
+    <div class="grid gap-4 sm:grid-cols-3 text-sm text-brand-steel">
+      <div class="bg-white border border-brand-steel/20 rounded-md p-4 flex flex-col items-center text-center gap-2 shadow" data-aos>
+        <i class="fa-solid fa-id-card text-2xl text-brand-orange"></i>
+        <span>ID required</span>
+      </div>
+      <div class="bg-white border border-brand-steel/20 rounded-md p-4 flex flex-col items-center text-center gap-2 shadow" data-aos data-aos-delay="50">
+        <i class="fa-solid fa-hard-hat text-2xl text-brand-orange"></i>
+        <span>PPE tips</span>
+      </div>
+      <div class="bg-white border border-brand-steel/20 rounded-md p-4 flex flex-col items-center text-center gap-2 shadow" data-aos data-aos-delay="100">
+        <i class="fa-solid fa-ban text-2xl text-brand-orange"></i>
+        <span>Prohibited items (Freon tanks, sealed drums, ammo)</span>
+      </div>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- style `Commercial Services` section with card layout and icons
- give `Before You Arrive` items cards and matching icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686853ca281c83299b777aef50139a1c