### PR TITLE
Fix favicon display

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <meta property="og:description" content="Fast, fair, and reliable scrap services in Demo City."/>
   <meta property="og:image" content="assets/og-image.jpg"/>
   <!-- Favicon -->
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml"/>
   <link rel="icon" href="assets/logo.png" type="image/png"/>
+  <link rel="icon" href="assets/logo.svg" type="image/svg+xml"/>
   <link rel="mask-icon" href="assets/logo.svg" color="#D75E02"/>
   <link rel="apple-touch-icon" href="assets/logo.png"/>
   <!-- Tailwind 3 CDN -->


### PR DESCRIPTION
## Summary
- ensure PNG icon is loaded before SVG so browsers that don't support SVG favicons still show the favicon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686859059c088329be4b17353cf724d4